### PR TITLE
[QW-0001]: Crear endpoint de búsqueda de usuario por documento de identidad

### DIFF
--- a/domain/model/src/main/java/co/com/crediya/model/user/gateways/UserRepository.java
+++ b/domain/model/src/main/java/co/com/crediya/model/user/gateways/UserRepository.java
@@ -11,11 +11,11 @@ public interface UserRepository {
     Mono<User> findById(UUID id);
     Flux<User> findAll();
 
-    Mono<Optional<User>> findByEmail(String email);
+    Mono<User> findByEmail(String email);
     Mono<Boolean> existsByEmail(String email);
     Mono<Boolean> existsByEmailExcludingId(String email, UUID excludeId);
 
-    Mono<Optional<User>> findByIdentityDocument(String identityDocument);
+    Mono<User> findByIdentityDocument(String identityDocument);
     Mono<Boolean> existsByIdentityDocument(String identityDocument);
     Mono<Boolean> existsByIdentityDocumentExcludingId(String identityDocument, UUID excludeId);
 

--- a/domain/usecase/src/main/java/co/com/crediya/usecase/getuserbyidentitydocument/GetUserByIdentityDocumentUseCase.java
+++ b/domain/usecase/src/main/java/co/com/crediya/usecase/getuserbyidentitydocument/GetUserByIdentityDocumentUseCase.java
@@ -1,0 +1,20 @@
+package co.com.crediya.usecase.getuserbyidentitydocument;
+
+import co.com.crediya.contract.ReactiveUseCase;
+import co.com.crediya.exception.UserNotFoundException;
+import co.com.crediya.model.user.User;
+import co.com.crediya.model.user.gateways.UserRepository;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@RequiredArgsConstructor
+public class GetUserByIdentityDocumentUseCase implements ReactiveUseCase<String, Mono<User>> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public Mono<User> execute(String identityDocument) {
+        return userRepository.findByIdentityDocument(identityDocument)
+                .switchIfEmpty(Mono.error(new UserNotFoundException()));
+    }
+}

--- a/domain/usecase/src/test/java/co/com/crediya/usecase/getuserbyidentitydocument/GetUserByIdentityDocumentUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/crediya/usecase/getuserbyidentitydocument/GetUserByIdentityDocumentUseCaseTest.java
@@ -1,0 +1,77 @@
+package co.com.crediya.usecase.getuserbyidentitydocument;
+
+import co.com.crediya.exception.UserNotFoundException;
+import co.com.crediya.model.common.gateways.TransactionalGateway;
+import co.com.crediya.model.role.enums.Roles;
+import co.com.crediya.model.user.User;
+import co.com.crediya.model.user.gateways.UserRepository;
+import co.com.crediya.usecase.getuserbyid.GetUserByIdUseCase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetUserByIdentityDocumentUseCaseTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TransactionalGateway transactionalGateway;
+
+    @InjectMocks
+    private GetUserByIdentityDocumentUseCase getUserByIdentityDocumentUseCase;
+
+    private User user;
+    private String identityDocument;
+
+    @BeforeEach
+    void setUp() {
+        identityDocument = "12345678";
+        user = User.builder()
+                .id(UUID.randomUUID())
+                .name("Jenner")
+                .lastName("Durand")
+                .email("jenner@crediya.com")
+                .identityDocument(identityDocument)
+                .telephone("987654321")
+                .roleId(Roles.CLIENT.getId())
+                .baseSalary(new BigDecimal("5000000"))
+                .build();
+    }
+
+    @Test
+    void shouldGetUserByIdentityDocumentSuccessfully() {
+        when(userRepository.findByIdentityDocument(identityDocument))
+                .thenReturn(Mono.just(user));
+
+        StepVerifier.create(getUserByIdentityDocumentUseCase.execute(identityDocument))
+                .expectNext(user)
+                .verifyComplete();
+
+        verify(userRepository).findByIdentityDocument(identityDocument);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUserNotFound() {
+        when(userRepository.findByIdentityDocument(identityDocument))
+                .thenReturn(Mono.empty());
+
+        StepVerifier.create(getUserByIdentityDocumentUseCase.execute(identityDocument))
+                .expectError(UserNotFoundException.class)
+                .verify();
+
+        verify(userRepository).findByIdentityDocument(identityDocument);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/crediya/r2dbc/adapter/UserReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/crediya/r2dbc/adapter/UserReactiveRepositoryAdapter.java
@@ -27,10 +27,9 @@ public class UserReactiveRepositoryAdapter extends ReactiveAdapterOperations<
     }
 
     @Override
-    public Mono<Optional<User>> findByEmail(String email) {
+    public Mono<User> findByEmail(String email) {
         return repository.findByEmail(email)
-                .map(userEntity -> userEntity.map(this::toEntity))
-                .defaultIfEmpty(Optional.empty());
+                .map(this::toEntity);
     }
 
     @Override
@@ -44,10 +43,9 @@ public class UserReactiveRepositoryAdapter extends ReactiveAdapterOperations<
     }
 
     @Override
-    public Mono<Optional<User>> findByIdentityDocument(String identityDocument) {
+    public Mono<User> findByIdentityDocument(String identityDocument) {
         return repository.findByIdentityDocument(identityDocument)
-                .map(userEntity -> userEntity.map(this::toEntity))
-                .defaultIfEmpty(Optional.empty());
+                .map(this::toEntity);
     }
 
     @Override

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/crediya/r2dbc/repository/UserReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/crediya/r2dbc/repository/UserReactiveRepository.java
@@ -9,11 +9,11 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface UserReactiveRepository extends ReactiveCrudRepository<UserEntity, UUID>, ReactiveQueryByExampleExecutor<UserEntity> {
-    Mono<Optional<UserEntity>> findByEmail(String email);
+    Mono<UserEntity> findByEmail(String email);
     Mono<Boolean> existsByEmail(String email);
     Mono<Boolean> existsByEmailAndIdNot(String email, UUID excludeId);
 
-    Mono<Optional<UserEntity>> findByIdentityDocument(String identityDocument);
+    Mono<UserEntity> findByIdentityDocument(String identityDocument);
     Mono<Boolean> existsByIdentityDocument(String identityDocument);
     Mono<Boolean> existsByIdentityDocumentAndIdNot(String identityDocument, UUID excludeId);
 }

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/test/java/co/com/crediya/r2dbc/UserReactiveRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/test/java/co/com/crediya/r2dbc/UserReactiveRepositoryAdapterTest.java
@@ -88,11 +88,11 @@ class UserReactiveRepositoryAdapterTest {
 
     @Test
     void mustFindByEmail() {
-        when(repository.findByEmail("jenner@crediya.com")).thenReturn(Mono.just(Optional.of(sampleEntity)));
+        when(repository.findByEmail("jenner@crediya.com")).thenReturn(Mono.just(sampleEntity));
         when(mapper.map(sampleEntity, User.class)).thenReturn(sampleUser);
 
         StepVerifier.create(repositoryAdapter.findByEmail("jenner@crediya.com"))
-                .expectNext(Optional.of(sampleUser))
+                .expectNext(sampleUser)
                 .verifyComplete();
     }
 
@@ -101,7 +101,7 @@ class UserReactiveRepositoryAdapterTest {
         when(repository.findByEmail("unknown@crediya.com")).thenReturn(Mono.empty());
 
         StepVerifier.create(repositoryAdapter.findByEmail("unknown@crediya.com"))
-                .expectNext(Optional.empty())
+                .expectNextCount(0)
                 .verifyComplete();
     }
 
@@ -125,11 +125,11 @@ class UserReactiveRepositoryAdapterTest {
 
     @Test
     void mustFindByIdentityDocument() {
-        when(repository.findByIdentityDocument("123456")).thenReturn(Mono.just(Optional.of(sampleEntity)));
+        when(repository.findByIdentityDocument("123456")).thenReturn(Mono.just(sampleEntity));
         when(mapper.map(sampleEntity, User.class)).thenReturn(sampleUser);
 
         StepVerifier.create(repositoryAdapter.findByIdentityDocument("123456"))
-                .expectNext(Optional.of(sampleUser))
+                .expectNext(sampleUser)
                 .verifyComplete();
     }
 
@@ -138,7 +138,7 @@ class UserReactiveRepositoryAdapterTest {
         when(repository.findByIdentityDocument("000000")).thenReturn(Mono.empty());
 
         StepVerifier.create(repositoryAdapter.findByIdentityDocument("000000"))
-                .expectNext(Optional.empty())
+                .expectNextCount(0)
                 .verifyComplete();
     }
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/UserRouterV1.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/UserRouterV1.java
@@ -28,6 +28,12 @@ public class UserRouterV1 {
                     beanClass = GetUserByIdHandlerV1.class,
                     beanMethod = "handle",
                     method = RequestMethod.GET
+            ),
+            @RouterOperation(
+                    path = "/api/v1/usuarios/identity-document/{identityDocument}",
+                    beanClass = GetUserByIdentityDocumentHandlerV1.class,
+                    beanMethod = "handle",
+                    method = RequestMethod.GET
             )
     })
     public RouterFunction<ServerResponse> routerFunction(

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/UserRouterV1.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/UserRouterV1.java
@@ -1,6 +1,7 @@
 package co.com.crediya.api.presentation.user.v1;
 
 import co.com.crediya.api.presentation.user.v1.handler.GetUserByIdHandlerV1;
+import co.com.crediya.api.presentation.user.v1.handler.GetUserByIdentityDocumentHandlerV1;
 import co.com.crediya.api.presentation.user.v1.handler.RegisterUserHandlerV1;
 import org.springdoc.core.annotations.RouterOperation;
 import org.springdoc.core.annotations.RouterOperations;
@@ -31,13 +32,15 @@ public class UserRouterV1 {
     })
     public RouterFunction<ServerResponse> routerFunction(
             RegisterUserHandlerV1 registerUserHandlerV1,
-            GetUserByIdHandlerV1 getUserByIdHandlerV1
+            GetUserByIdHandlerV1 getUserByIdHandlerV1,
+            GetUserByIdentityDocumentHandlerV1 getUserByIdentityDocumentHandlerV1
     ) {
         return RouterFunctions
                 .route()
                 .path("/api/v1/usuarios", builder ->
                         builder
                                 .POST("", registerUserHandlerV1::handle)
+                                .GET("identity-document/{identityDocument}", getUserByIdentityDocumentHandlerV1::handle)
                                 .GET("/{id}", getUserByIdHandlerV1::handle)
                 ).build();
     }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/handler/GetUserByIdentityDocumentHandlerV1.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/handler/GetUserByIdentityDocumentHandlerV1.java
@@ -4,8 +4,6 @@ import co.com.crediya.api.dto.common.ErrorResponseDTO;
 import co.com.crediya.api.dto.user.UserDTO;
 import co.com.crediya.api.mapper.UserDTOMapper;
 import co.com.crediya.api.presentation.contract.RouteHandler;
-import co.com.crediya.api.presentation.contract.UUIDValidator;
-import co.com.crediya.usecase.getuserbyid.GetUserByIdUseCase;
 import co.com.crediya.usecase.getuserbyidentitydocument.GetUserByIdentityDocumentUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/handler/GetUserByIdentityDocumentHandlerV1.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/handler/GetUserByIdentityDocumentHandlerV1.java
@@ -1,0 +1,57 @@
+package co.com.crediya.api.presentation.user.v1.handler;
+
+import co.com.crediya.api.dto.common.ErrorResponseDTO;
+import co.com.crediya.api.dto.user.UserDTO;
+import co.com.crediya.api.mapper.UserDTOMapper;
+import co.com.crediya.api.presentation.contract.RouteHandler;
+import co.com.crediya.api.presentation.contract.UUIDValidator;
+import co.com.crediya.usecase.getuserbyid.GetUserByIdUseCase;
+import co.com.crediya.usecase.getuserbyidentitydocument.GetUserByIdentityDocumentUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class GetUserByIdentityDocumentHandlerV1 implements RouteHandler {
+
+    private final GetUserByIdentityDocumentUseCase getUserByIdentityDocumentUseCase;
+    private final UserDTOMapper userDTOMapper;
+
+    @Operation(
+            tags = {"User API"},
+            summary = "Obtener usuario por documento de identidad",
+            description = "Permite obtener la información de un usuario a partir de su documento de identidad",
+            parameters = {
+                    @Parameter(
+                            name = "identityDocument",
+                            in = ParameterIn.PATH,
+                            description = "Documento de identidad del usuario",
+                            required = true,
+                            example = "87978659"
+                    )
+            }
+    )
+    @ApiResponse(responseCode = "200", description = "Usuario obtenido correctamente",
+            content = @Content(schema = @Schema(implementation = UserDTO.class)))
+    @ApiResponse(responseCode = "404", description = "Usuario no encontrado",
+            content = @Content(schema = @Schema(implementation = ErrorResponseDTO.class)))
+    @ApiResponse(responseCode = "500", description = "Error interno del servidor",
+            content = @Content(schema = @Schema(implementation = ErrorResponseDTO.class)))
+    public Mono<ServerResponse> handle(ServerRequest serverRequest) {
+        return Mono.fromCallable(serverRequest.pathVariable("identityDocument")::toString)
+                .flatMap(getUserByIdentityDocumentUseCase::execute)
+                .map(userDTOMapper::toUserDTOFromModel)
+                .flatMap(user -> ServerResponse.ok().bodyValue(user));
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/api/v1/UserRouterV1Test.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/api/v1/UserRouterV1Test.java
@@ -7,10 +7,12 @@ import co.com.crediya.api.presentation.contract.DTOValidator;
 import co.com.crediya.api.presentation.contract.UUIDValidator;
 import co.com.crediya.api.presentation.user.v1.UserRouterV1;
 import co.com.crediya.api.presentation.user.v1.handler.GetUserByIdHandlerV1;
+import co.com.crediya.api.presentation.user.v1.handler.GetUserByIdentityDocumentHandlerV1;
 import co.com.crediya.api.presentation.user.v1.handler.RegisterUserHandlerV1;
 import co.com.crediya.model.role.enums.Roles;
 import co.com.crediya.model.user.User;
 import co.com.crediya.usecase.getuserbyid.GetUserByIdUseCase;
+import co.com.crediya.usecase.getuserbyidentitydocument.GetUserByIdentityDocumentUseCase;
 import co.com.crediya.usecase.registeruser.RegisterUserUseCase;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -28,7 +30,12 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.UUID;
 
-@ContextConfiguration(classes = {UserRouterV1.class, RegisterUserHandlerV1.class, GetUserByIdHandlerV1.class})
+@ContextConfiguration(classes = {
+        UserRouterV1.class,
+        RegisterUserHandlerV1.class,
+        GetUserByIdHandlerV1.class,
+        GetUserByIdentityDocumentHandlerV1.class,
+})
 @WebFluxTest
 class UserRouterV1Test {
 
@@ -40,6 +47,9 @@ class UserRouterV1Test {
 
     @MockitoBean
     private GetUserByIdUseCase getUserByIdUseCase;
+
+    @MockitoBean
+    private GetUserByIdentityDocumentUseCase getUserByIdentityDocumentUseCase;
 
     @MockitoBean
     private UserDTOMapper userDTOMapper;
@@ -144,6 +154,52 @@ class UserRouterV1Test {
 
         webTestClient.get()
                 .uri("/api/v1/usuarios/{id}", sampleId.toString())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(UserDTO.class)
+                .value(userResponse -> {
+                    Assertions
+                            .assertThat(userResponse.email())
+                            .isEqualTo("jenner@crediya.com");
+                });
+    }
+
+    @Test
+    void testGetUserByIdentityDocumentSuccess() {
+        var identityDocument = "12345678";
+        var sampleId = UUID.randomUUID();
+
+        var user = new User(
+                sampleId,
+                "Jenner",
+                "Durand",
+                LocalDate.of(1991, 1, 1),
+                "Calle 123 # 45-67",
+                "jenner@crediya.com",
+                "12345678",
+                "98765432",
+                Roles.CLIENT.getId(),
+                new BigDecimal("3000000")
+        );
+
+        var responseDTO = new UserDTO(
+                sampleId.toString(),
+                "Jenner",
+                "Durand",
+                "1991-01-01",
+                "Calle 123 # 45-67",
+                "jenner@crediya.com",
+                "12345678",
+                "98765432",
+                Roles.CLIENT.getId().toString(),
+                new BigDecimal("3000000")
+        );
+
+        when(getUserByIdentityDocumentUseCase.execute(identityDocument)).thenReturn(Mono.just(user));
+        when(userDTOMapper.toUserDTOFromModel(user)).thenReturn(responseDTO);
+
+        webTestClient.get()
+                .uri("/api/v1/usuarios/identity-document/{identityDocument}", identityDocument)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(UserDTO.class)


### PR DESCRIPTION
## Description  
Crear un nuevo endpoint que permita obtener un usuario a partir de su documento de identidad. Además, se refactorizo el repositorio y adaptadores.

## Included Changes

- Implement `GetUserByIdentityDocumentUseCase` to encapsulate the lookup logic.  
- Add endpoint `GET /api/v1/usuarios/identity-document/{identityDocument}` with router and handler (`UserRouterV1`, `GetUserByIdentityDocumentHandlerV1`).  
- Refactor `UserRepository`, `UserReactiveRepositoryAdapter`, and `UserReactiveRepository` to return `Mono<User>` instead of `Mono<Optional<User>>`.  
- Update adapter and router tests.  
- Add unit tests for the new use case and endpoint.  
- Register the new handler and use case in application configuration and test contexts.  

## Endpoints  

- `GET /api/v1/usuarios/identity-document/{identityDocument}`  