### PR TITLE
[QW-0002]: Crear endpoint de listado de usuarios por documentos de identidad

### DIFF
--- a/domain/model/src/main/java/co/com/crediya/model/user/gateways/UserRepository.java
+++ b/domain/model/src/main/java/co/com/crediya/model/user/gateways/UserRepository.java
@@ -4,12 +4,14 @@ import co.com.crediya.model.user.User;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository {
     Mono<User> findById(UUID id);
     Flux<User> findAll();
+    Flux<User> findAllByIdentityDocuments(List<String> identityDocuments);
 
     Mono<User> findByEmail(String email);
     Mono<Boolean> existsByEmail(String email);

--- a/domain/usecase/src/main/java/co/com/crediya/usecase/listusersbyidentitydocuments/ListUsersByIdentityDocumentsUseCase.java
+++ b/domain/usecase/src/main/java/co/com/crediya/usecase/listusersbyidentitydocuments/ListUsersByIdentityDocumentsUseCase.java
@@ -1,0 +1,20 @@
+package co.com.crediya.usecase.listusersbyidentitydocuments;
+
+import co.com.crediya.contract.ReactiveUseCase;
+import co.com.crediya.model.user.User;
+import co.com.crediya.model.user.gateways.UserRepository;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class ListUsersByIdentityDocumentsUseCase implements ReactiveUseCase<List<String>, Flux<User>> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public Flux<User> execute(List<String> identityDocuments) {
+        return userRepository.findAllByIdentityDocuments(identityDocuments);
+    }
+}

--- a/domain/usecase/src/test/java/co/com/crediya/usecase/listusersbyidentitydocuments/ListUsersByIdentityDocumentsUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/crediya/usecase/listusersbyidentitydocuments/ListUsersByIdentityDocumentsUseCaseTest.java
@@ -1,0 +1,85 @@
+package co.com.crediya.usecase.listusersbyidentitydocuments;
+
+import co.com.crediya.model.role.enums.Roles;
+import co.com.crediya.model.user.User;
+import co.com.crediya.model.user.gateways.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ListUsersByIdentityDocumentsUseCaseTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ListUsersByIdentityDocumentsUseCase listUsersByIdentityDocumentsUseCase;
+
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        user1 = User.builder()
+                .id(UUID.randomUUID())
+                .name("Jenner")
+                .lastName("Durand")
+                .email("jenner@crediya.com")
+                .identityDocument("12345678")
+                .telephone("987654321")
+                .roleId(Roles.CLIENT.getId())
+                .baseSalary(new BigDecimal("50000"))
+                .build();
+
+        user2 = User.builder()
+                .id(UUID.randomUUID())
+                .name("Carlos")
+                .lastName("Perez")
+                .email("carlos@crediya.com")
+                .identityDocument("87654321")
+                .telephone("123456789")
+                .roleId(Roles.ADVISOR.getId())
+                .baseSalary(new BigDecimal("70000"))
+                .build();
+    }
+
+    @Test
+    void shouldReturnUsersWhenIdentityDocumentsMatch() {
+        var documents = List.of("12345678", "87654321");
+
+        when(userRepository.findAllByIdentityDocuments(documents))
+                .thenReturn(Flux.just(user1, user2));
+
+        StepVerifier.create(listUsersByIdentityDocumentsUseCase.execute(documents))
+                .expectNext(user1)
+                .expectNext(user2)
+                .verifyComplete();
+
+        verify(userRepository).findAllByIdentityDocuments(documents);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNoUsersFound() {
+        var documents = List.of("00000000");
+
+        when(userRepository.findAllByIdentityDocuments(documents))
+                .thenReturn(Flux.empty());
+
+        StepVerifier.create(listUsersByIdentityDocumentsUseCase.execute(documents))
+                .verifyComplete();
+
+        verify(userRepository).findAllByIdentityDocuments(documents);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/crediya/r2dbc/adapter/UserReactiveRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/crediya/r2dbc/adapter/UserReactiveRepositoryAdapter.java
@@ -7,8 +7,10 @@ import co.com.crediya.r2dbc.helper.ReactiveAdapterOperations;
 import co.com.crediya.r2dbc.repository.UserReactiveRepository;
 import org.reactivecommons.utils.ObjectMapper;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -24,6 +26,12 @@ public class UserReactiveRepositoryAdapter extends ReactiveAdapterOperations<
             UserReactiveRepository repository,
             ObjectMapper mapper) {
         super(repository, mapper, d -> mapper.map(d, User.class));
+    }
+
+    @Override
+    public Flux<User> findAllByIdentityDocuments(List<String> identityDocuments) {
+        return repository.findAllByIdentityDocumentIn(identityDocuments)
+                .map(this::toEntity);
     }
 
     @Override

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/crediya/r2dbc/repository/UserReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/main/java/co/com/crediya/r2dbc/repository/UserReactiveRepository.java
@@ -3,8 +3,10 @@ package co.com.crediya.r2dbc.repository;
 import co.com.crediya.r2dbc.entity.UserEntity;
 import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,4 +18,6 @@ public interface UserReactiveRepository extends ReactiveCrudRepository<UserEntit
     Mono<UserEntity> findByIdentityDocument(String identityDocument);
     Mono<Boolean> existsByIdentityDocument(String identityDocument);
     Mono<Boolean> existsByIdentityDocumentAndIdNot(String identityDocument, UUID excludeId);
+
+    Flux<UserEntity> findAllByIdentityDocumentIn(Collection<String> identityDocuments);
 }

--- a/infrastructure/driven-adapters/r2dbc-mysql/src/test/java/co/com/crediya/r2dbc/UserReactiveRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-mysql/src/test/java/co/com/crediya/r2dbc/UserReactiveRepositoryAdapterTest.java
@@ -17,6 +17,7 @@ import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -132,6 +133,71 @@ class UserReactiveRepositoryAdapterTest {
 
         StepVerifier.create(repositoryAdapter.findByIdentityDocument("123456"))
                 .expectNext(sampleUser)
+                .verifyComplete();
+    }
+
+    @Test
+    void mustFindAllByIdentityDocuments() {
+        var user1 = User.builder()
+                .id(UUID.randomUUID())
+                .name("Jenner")
+                .lastName("Durand")
+                .email("jenner@crediya.com")
+                .identityDocument("12345678")
+                .telephone("987654321")
+                .roleId(Roles.CLIENT.getId())
+                .baseSalary(new BigDecimal("50000"))
+                .build();
+
+        var userEntity1 = new UserEntity(
+                user1.getId(),
+                user1.getName(),
+                user1.getLastName(),
+                user1.getBirthDate(),
+                user1.getAddress(),
+                user1.getEmail(),
+                user1.getPassword(),
+                user1.getIdentityDocument(),
+                user1.getTelephone(),
+                user1.getRoleId(),
+                user1.getBaseSalary()
+        );
+
+        var user2 = User.builder()
+                .id(UUID.randomUUID())
+                .name("Carlos")
+                .lastName("Perez")
+                .email("carlos@crediya.com")
+                .identityDocument("87654321")
+                .telephone("123456789")
+                .roleId(Roles.ADVISOR.getId())
+                .baseSalary(new BigDecimal("70000"))
+                .build();
+
+        var userEntity2 = new UserEntity(
+                user2.getId(),
+                user2.getName(),
+                user2.getLastName(),
+                user2.getBirthDate(),
+                user2.getAddress(),
+                user2.getEmail(),
+                user2.getPassword(),
+                user2.getIdentityDocument(),
+                user2.getTelephone(),
+                user2.getRoleId(),
+                user2.getBaseSalary()
+        );
+
+        when(mapper.map(userEntity1, User.class)).thenReturn(user1);
+        when(mapper.map(userEntity2, User.class)).thenReturn(user2);
+
+        var identityDocuments = List.of("12345678", "87654321");
+        when(repository.findAllByIdentityDocumentIn(identityDocuments))
+                .thenReturn(Flux.just(userEntity1, userEntity2));
+
+        StepVerifier.create(repositoryAdapter.findAllByIdentityDocuments(identityDocuments))
+                .expectNextMatches(userResponse1 -> userResponse1.getId().equals(user1.getId()))
+                .expectNextMatches(userResponse2 -> userResponse2.getId().equals(user2.getId()))
                 .verifyComplete();
     }
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/dto/user/SearchListUsersByIdentityDocumentsDTO.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/dto/user/SearchListUsersByIdentityDocumentsDTO.java
@@ -1,0 +1,7 @@
+package co.com.crediya.api.dto.user;
+
+import java.util.List;
+
+public record SearchListUsersByIdentityDocumentsDTO(
+        List<String> identityDocuments
+) { }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/UserRouterV1.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/UserRouterV1.java
@@ -2,6 +2,7 @@ package co.com.crediya.api.presentation.user.v1;
 
 import co.com.crediya.api.presentation.user.v1.handler.GetUserByIdHandlerV1;
 import co.com.crediya.api.presentation.user.v1.handler.GetUserByIdentityDocumentHandlerV1;
+import co.com.crediya.api.presentation.user.v1.handler.ListUsersByIdentityDocumentsHandlerV1;
 import co.com.crediya.api.presentation.user.v1.handler.RegisterUserHandlerV1;
 import org.springdoc.core.annotations.RouterOperation;
 import org.springdoc.core.annotations.RouterOperations;
@@ -34,18 +35,26 @@ public class UserRouterV1 {
                     beanClass = GetUserByIdentityDocumentHandlerV1.class,
                     beanMethod = "handle",
                     method = RequestMethod.GET
+            ),
+            @RouterOperation(
+                    path = "/api/v1/usuarios/identity-documents",
+                    beanClass = ListUsersByIdentityDocumentsHandlerV1.class,
+                    beanMethod = "handle",
+                    method = RequestMethod.POST
             )
     })
     public RouterFunction<ServerResponse> routerFunction(
             RegisterUserHandlerV1 registerUserHandlerV1,
             GetUserByIdHandlerV1 getUserByIdHandlerV1,
-            GetUserByIdentityDocumentHandlerV1 getUserByIdentityDocumentHandlerV1
+            GetUserByIdentityDocumentHandlerV1 getUserByIdentityDocumentHandlerV1,
+            ListUsersByIdentityDocumentsHandlerV1 listUsersByIdentityDocumentsHandlerV1
     ) {
         return RouterFunctions
                 .route()
                 .path("/api/v1/usuarios", builder ->
                         builder
                                 .POST("", registerUserHandlerV1::handle)
+                                .POST("/identity-documents", listUsersByIdentityDocumentsHandlerV1::handle)
                                 .GET("identity-document/{identityDocument}", getUserByIdentityDocumentHandlerV1::handle)
                                 .GET("/{id}", getUserByIdHandlerV1::handle)
                 ).build();

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/handler/ListUsersByIdentityDocumentsHandlerV1.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/presentation/user/v1/handler/ListUsersByIdentityDocumentsHandlerV1.java
@@ -1,0 +1,72 @@
+package co.com.crediya.api.presentation.user.v1.handler;
+
+import co.com.crediya.api.contract.RoleValidator;
+import co.com.crediya.api.contract.RouteHandler;
+import co.com.crediya.api.contract.UUIDValidator;
+import co.com.crediya.api.dto.common.ErrorResponseDTO;
+import co.com.crediya.api.dto.user.SearchListUsersByIdentityDocumentsDTO;
+import co.com.crediya.api.dto.user.UserDTO;
+import co.com.crediya.api.mapper.UserDTOMapper;
+import co.com.crediya.model.role.enums.Roles;
+import co.com.crediya.usecase.getuserbyid.GetUserByIdUseCase;
+import co.com.crediya.usecase.listusersbyidentitydocuments.ListUsersByIdentityDocumentsUseCase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ListUsersByIdentityDocumentsHandlerV1 implements RouteHandler {
+
+    private final ListUsersByIdentityDocumentsUseCase listUsersByIdentityDocumentsUseCase;
+    private final UserDTOMapper userDTOMapper;
+    private final RoleValidator roleValidator;
+
+    @Operation(
+            tags = {"User API"},
+            summary = "Obtener listado de usuarios por documentos de identidad",
+            description = "Permite obtener un listado de usuarios a partir de una lista de documentos de identidad",
+            requestBody = @RequestBody(
+                    description = "Lista de documentos de identidad",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(implementation = SearchListUsersByIdentityDocumentsDTO.class))
+            )
+    )
+    @ApiResponse(responseCode = "200", description = "Usuarios obtenidos correctamente",
+            content = @Content(array = @ArraySchema(schema = @Schema(implementation = UserDTO.class))))
+    @ApiResponse(responseCode = "401", description = "No autorizado",
+            content = @Content(schema = @Schema))
+    @ApiResponse(responseCode = "422", description = "Error de validación",
+            content = @Content(schema = @Schema(implementation = ErrorResponseDTO.class)))
+    @ApiResponse(responseCode = "500", description = "Error interno del servidor",
+            content = @Content(schema = @Schema(implementation = ErrorResponseDTO.class)))
+    public Mono<ServerResponse> handle(ServerRequest request) {
+        return request
+                .bodyToMono(SearchListUsersByIdentityDocumentsDTO.class)
+                .flatMap(dto -> roleValidator.validateRole(Roles.ADVISOR).thenReturn(dto))
+                .doOnNext(user -> {
+                    var rid = request.exchange().getRequest().getId();
+                    log.info("[{}] POST /v1/usuarios/identity-documents - Listar usuarios por documentos de identidad", rid);
+                })
+                .map(SearchListUsersByIdentityDocumentsDTO::identityDocuments)
+                .flatMapMany(listUsersByIdentityDocumentsUseCase::execute)
+                .map(userDTOMapper::toUserDTOFromModel)
+                .collectList()
+                .flatMap(users -> ServerResponse.ok().bodyValue(users));
+    }
+}


### PR DESCRIPTION
## Description  
Crear un nuevo endpoint que permita obtener un listado de usuarios teniendo como filtro un listado de documentos de identidad.

## Included Changes

- Add new method to find users by identity documents in user repository.
- Add List Users By Identity Documents use case.
- Add List Users By Identity Documents POST endpoint.
- Add DTO for the new endpoint.
- Add find users by identity documents repository adapter implementation.
- Add tests for the new use case and endpoint.

## Endpoints  

- `POST /api/v1/usuarios/identity-documents`  Requiere como rol `ADVISOR` para poder ser utilizado.